### PR TITLE
Use strict comparison operator - tiny fix

### DIFF
--- a/js/freaky-controls.md
+++ b/js/freaky-controls.md
@@ -28,8 +28,8 @@ $(".numeric").keypress(function(e){
 #### How it should be?
 ```javascript
 $(".numeric").on('keypress', function(e){
-    if (e.which != 8 && e.which != 0 && (e.which < 48 || e.which > 57)) {
-		return false;
+    if (e.which !== 8 && e.which !== 0 && (e.which < 48 || e.which > 57)) {
+	return false;
     }
 });
 ```


### PR DESCRIPTION
It's always better using `===` and `!==` instead of `==` and `!=`.
